### PR TITLE
Fix context menu wrapper call

### DIFF
--- a/monks-tokenbar.js
+++ b/monks-tokenbar.js
@@ -172,10 +172,12 @@ export class MonksTokenBar {
         });
 
         patchFunc("ChatLog.prototype._getEntryContextOptions", function (wrapped, ...args) {
-            let menu = wrapped.call(...args);
+            let menu = wrapped(...args);
 
             let canHeroPointReroll = ($li) => {
-                const message = game.messages.get($li.getAttribute('data-message-id'), { strict: !0 });
+                const messageId = $li[0]?.dataset?.messageId;
+                if (!messageId) return false;
+                const message = game.messages.get(messageId, { strict: !0 });
                 if (!message.getFlag("monks-tokenbar", "what"))
                     return false;
 
@@ -192,7 +194,9 @@ export class MonksTokenBar {
                 //message.isRerollable && !!actor?.isOfType("character") && actor.heroPoints.value > 0
             };
             let canReroll = ($li) => {
-                const message = game.messages.get($li.getAttribute('data-message-id'), { strict: !0 });
+                const messageId = $li[0]?.dataset?.messageId;
+                if (!messageId) return false;
+                const message = game.messages.get(messageId, { strict: !0 });
 
                 if (!MonksTokenBar.system.canReroll)
                     return false;
@@ -216,7 +220,9 @@ export class MonksTokenBar {
                     icon: '<i class="fas fa-hospital-symbol"></i>',
                     condition: canHeroPointReroll,
                     callback: $li => {
-                        const message = game.messages.get($li.getAttribute('data-message-id'), { strict: !0 });
+                        const messageId = $li[0]?.dataset?.messageId;
+                        if (!messageId) return;
+                        const message = game.messages.get(messageId, { strict: !0 });
                         let what = message.getFlag("monks-tokenbar", "what");
                         if (what == "savingthrow")
                             SavingThrow.rerollFromMessage(message, MonksTokenBar.contextId, { heroPoint: !0 });
@@ -229,7 +235,9 @@ export class MonksTokenBar {
                     icon: '<i class="fas fa-dice"></i>',
                     condition: canReroll,
                     callback: $li => {
-                        const message = game.messages.get($li.getAttribute('data-message-id'), { strict: !0 });
+                        const messageId = $li[0]?.dataset?.messageId;
+                        if (!messageId) return;
+                        const message = game.messages.get(messageId, { strict: !0 });
                         let what = message.getFlag("monks-tokenbar", "what");
                         if (what == "savingthrow")
                             SavingThrow.rerollFromMessage(message, MonksTokenBar.contextId);
@@ -242,7 +250,9 @@ export class MonksTokenBar {
                     icon: '<i class="fas fa-dice-one"></i>',
                     condition: canReroll,
                     callback: $li => {
-                        const message = game.messages.get($li.getAttribute('data-message-id'), { strict: !0 });
+                        const messageId = $li[0]?.dataset?.messageId;
+                        if (!messageId) return;
+                        const message = game.messages.get(messageId, { strict: !0 });
                         let what = message.getFlag("monks-tokenbar", "what");
                         if (what == "savingthrow")
                             SavingThrow.rerollFromMessage(message, MonksTokenBar.contextId, { keep: "worst" });
@@ -255,7 +265,9 @@ export class MonksTokenBar {
                     icon: '<i class="fas fa-dice-six"></i>',
                     condition: canReroll,
                     callback: $li => {
-                        const message = game.messages.get($li.getAttribute('data-message-id'), { strict: !0 });
+                        const messageId = $li[0]?.dataset?.messageId;
+                        if (!messageId) return;
+                        const message = game.messages.get(messageId, { strict: !0 });
                         let what = message.getFlag("monks-tokenbar", "what");
                         if (what == "savingthrow")
                             SavingThrow.rerollFromMessage(message, MonksTokenBar.contextId, { keep: "best" });


### PR DESCRIPTION
## Summary
- fix call to wrapped function when adding chat context menu options
- handle dataset lookups for chat messages in PF2e reroll menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866a86c14c8327ba3491c9da845d22